### PR TITLE
Added Dependency Management with requires.io, froze pip requirements

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -19,6 +19,10 @@ Badges
     :target: http://omicron-server.readthedocs.org/en/latest/?badge=latest
     :alt: Documentation Status
 
+.. image:: https://requires.io/github/MichalKononenko/OmicronServer/requirements.svg?branch=master
+     :target: https://requires.io/github/MichalKononenko/OmicronServer/requirements/?branch=master
+     :alt: Requirements Status
+
 Installation
 ------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,24 +1,42 @@
-# Flask Application
-flask
-flask-restful
-itsdangerous
-
-# Data management
-sqlalchemy
-sqlalchemy-migrate
-jsonschema
-psycopg2
-
-# Password management
-flask-httpauth
-passlib
-
-# Testing
-coverage
-mock
-coveralls
-
-# Documentation Building
-sphinx
-sphinxcontrib-httpdomain
-sphinx-autobuild
+alabaster==0.7.6
+aniso8601==1.1.0
+argh==0.26.1
+Babel==2.1.1
+colorama==0.3.3
+coverage==4.0.2
+coveralls==1.1
+decorator==4.0.4
+docopt==0.6.2
+docutils==0.12
+Flask==0.10.1
+Flask-HTTPAuth==2.7.0
+Flask-RESTful==0.3.4
+itsdangerous==0.24
+Jinja2==2.8
+jsonschema==2.5.1
+livereload==2.4.0
+MarkupSafe==0.23
+mock==1.3.0
+passlib==1.6.5
+pathtools==0.1.2
+pbr==1.8.1
+psycopg2==2.6.1
+Pygments==2.0.2
+python-dateutil==2.4.2
+pytz==2015.7
+PyYAML==3.11
+requests==2.8.1
+six==1.10.0
+snowballstemmer==1.2.0
+Sphinx==1.3.1
+sphinx-autobuild==0.5.2
+sphinx-rtd-theme==0.1.9
+sphinxcontrib-httpdomain==1.4.0
+SQLAlchemy==1.0.9
+sqlalchemy-migrate==0.10.0
+sqlparse==0.1.18
+Tempita==0.5.2
+tornado==4.3
+watchdog==0.8.3
+Werkzeug==0.11.2
+wheel==0.26.0


### PR DESCRIPTION
Inspired by [Miguel Grinberg's Article](http://blog.miguelgrinberg.com/post/the-package-dependency-blues) and [David-DM](https://david-dm.org/MichalKononenko/OmicronClient#info=devDependencies&view=table)'s use on the [OmicronClient](https://github.com/MichalKononenko/OmicronClient) to manage dependencies, I figure using [requires.io](https://requires.io/github/MichalKononenko/OmicronServer/requirements/?branch=master) to track package dependencies would be a good idea.

With this, we can use ```pip freeze > requirements.txt``` to specify what versions of Python libraries we need for the Omicron Server, and so stop headaches associated with deployment if someone announces a breaking change to one of the dependencies.