### PR TITLE
Tokens now return expiration date.

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -77,20 +77,23 @@ def create_token():
         Content-Type: application/json
 
         {
-            "token": "1294DKJFKAJ9224ALSJDL1J23"
+            "token": "a409a362-d733-11e5-b625-7e14f79230d0",
+            "expiration_date": "2015-01-01T12:00:00"
         }
 
     :return: A Flask response object with the token jsonified into ASCII
     """
     try:
-        token = g.user.generate_auth_token(
+        token, expiration_date = g.user.generate_auth_token(
             expiration=int(request.args.get('expiration'))
         )
     except TypeError:
         log.debug('No expiration supplied, using default expiration time')
-        token = g.user.generate_auth_token()
+        token, expiration_date = g.user.generate_auth_token()
     response = jsonify(
-            {'token': token}
+            {'token': token,
+             'expiration_date': expiration_date.isoformat()
+        }
     )
     response.status_code = 201
     return response

--- a/database/models/users.py
+++ b/database/models/users.py
@@ -169,8 +169,10 @@ class User(Base):
             default, this is a :class:`ContextManagedSession` that will
             point to :attr:`conf.DATABASE_ENGINE`, but for the purposes of unit
             testing, it can be repointed.
-        :return: The newly-created authentication token
-        :rtype: str
+        :return: A tuple containing the newly-created authentication token,
+            and the expiration date of the new token. The expiration date
+            is an object of type :class:`Datetime`
+        :rtype: tuple(str, Datetime)
 
         .. _UUID 1: https://goo.gl/iUS6s9
         """
@@ -185,7 +187,7 @@ class User(Base):
             token = Token(token_string, expiration_date, owner=user)
             session.add(token)
 
-        return token_string
+        return token_string, expiration_date
 
     def verify_auth_token(self, token_string):
         """

--- a/tests/unit/test_database/test_models/test_users.py
+++ b/tests/unit/test_database/test_models/test_users.py
@@ -220,17 +220,17 @@ class TestGenerateAuthToken(TestUser):
     def setUp(self):
         TestUser.setUp(self)
         self.user = database.models.users.User(self.username, self.password, self.email)
-        self.mock_token = uuid1()
+        self.mock_token_return_value = uuid1()
 
     @mock.patch('sqlalchemy.orm.Session.add')
     @mock.patch('database.models.users.uuid1')
     @mock.patch('sqlalchemy.orm.Query.first')
     def test_generate_auth_token(self, mock_first, mock_guid, mock_add):
-        mock_guid.return_value = self.mock_token
+        mock_guid.return_value = self.mock_token_return_value
         mock_first.return_value = self.user
 
-        token = self.user.generate_auth_token()
-        self.assertEqual(str(self.mock_token), token)
+        token = self.user.generate_auth_token()[0]
+        self.assertEqual(str(self.mock_token_return_value), token)
 
         self.assertTrue(mock_guid.called)
         self.assertTrue(mock_add.called)


### PR DESCRIPTION
Return the expiration date of the token along with the token string when a post request is made to /api/v1/token. Initially, I thought this would be redundant, as the client would know how long the token expiry period is, but now that the UI is getting coded, it makes more sense to send the expiration date for the token along with the token.